### PR TITLE
Add credentials: include to fetch requests

### DIFF
--- a/api.js
+++ b/api.js
@@ -48,7 +48,7 @@ function setHostAddress(){
 
 
 async function getModels(){
-  const response = await fetch(`${ollama_host}/api/tags`);
+  const response = await fetch(`${ollama_host}/api/tags`, {credentials: 'include'});
   const data = await response.json();
   return data;
 }
@@ -63,7 +63,8 @@ function postRequest(data, signal) {
       'Content-Type': 'application/json'
     },
     body: JSON.stringify(data),
-    signal: signal
+    signal: signal,
+    credentials: 'include',
   });
 }
 


### PR DESCRIPTION
Allow use over connections which require cookies for authentication.

I work on Google Colab and have just been playing with ollama-ui to run the UI running on the remote VM for experimentation purposes. Network traffic to the remote VM is gated by cookies but the cross-origin request omits cookies by default.

With this tweak I can use the UI over a private connection to the remote VM.