### PR TITLE
Fixed firefox streams not working, Firefox support #24

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html>
 
 <head>
-    <title>Chat with Llama2</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
+  <title>Chat with Llama2</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
     <link href="resources/bootstrap.min.css" rel="stylesheet"
         integrity="sha384-4bw+/aepP/YC94hEpVNVgiZdgIC5+VKNBQNGCHeKRQN+PtmoHDEXuppvnDJzQIu9" crossorigin="anonymous">
     <script src="resources/bootstrap.bundle.min.js"
@@ -17,99 +17,99 @@
         crossorigin="anonymous"></script>
     <script src="resources/jquery-3.7.1.min.js" integrity="sha384-1H217gwSVyLSIfaLxHbE7dRb3v4mYCKbpQvzx0cegeju1MVsGrX5xXxAvs/HgeFs"
         crossorigin="anonymous"></script>
-    <link rel="stylesheet" href="chat.css">
+  <link rel="stylesheet" href="chat.css">
 </head>
 
 <body data-bs-theme="dark">
-    <div class="container">
-            <div id="scroll-wrapper">
-                <div id="chat-container" class="card">
-                    <div class="card-body">
-                        <div id="chat-history"></div>
-                    </div>
-            </div>
-                        </div>
-                    </div>
+  <div class="container">
+    <div id="scroll-wrapper">
+      <div id="chat-container" class="card">
+        <div class="card-body">
+          <div id="chat-history"></div>
+        </div>
+      </div>
+    </div>
+  </div>
 
-        <div class="position-fixed w-100" style="z-index: 9999; top: 0px; height: 200px; background: linear-gradient(180deg, black, transparent);">
+  <div class="position-fixed w-100" style="z-index: 9999; top: 0px; height: 200px; background: linear-gradient(180deg, black, transparent);">
 
-          <div class="position-fixed w-100" style="z-index: 9999; top: 0px; height: 200px;  background: linear-gradient(180deg, black, transparent);">
-            <div class="d-flex justify-content-between align-items-center m-0" style="padding: 16px;">
-                <h1>Chat with Ollama</h1>
-                <!-- Model dropdown -->
-                <div class="d-flex align-items-center m-1">
-                  <div class="p-2 flex-grow-1 bd-highlight">
-                    <label for="system-prompt" class="me-2" style="font-size: normal;">System Prompt</label>
+    <div class="position-fixed w-100" style="z-index: 9999; top: 0px; height: 200px;  background: linear-gradient(180deg, black, transparent);">
+      <div class="d-flex justify-content-between align-items-center m-0" style="padding: 16px;">
+        <h1>Chat with Ollama</h1>
+        <!-- Model dropdown -->
+        <div class="d-flex align-items-center m-1">
+          <div class="p-2 flex-grow-1 bd-highlight">
+            <label for="system-prompt" class="me-2" style="font-size: normal;">System Prompt</label>
                     <input id="system-prompt" class="form-control" type="text" placeholder="You are a helpful assistant" style="width: auto;"></select>
-                    <label for="host-address" class="me-2" style="font-size: normal;">Hostname</label>
-                    <input id="host-address" class="form-control" type="text" placeholder="http://localhost:11434" style="width: auto;"></select>
+            <label for="host-address" class="me-2" style="font-size: normal;">Hostname</label>
+            <input id="host-address" class="form-control" type="text" placeholder="http://localhost:11434" style="width: auto;"></select>
 
-                  </div>
-                <div class="d-flex align-items-center m-2">
-                    <div class="p-2 flex-grow-1 bd-highlight">
-                        <label for="model-select" class="me-2" style="font-size: normal;">Model:</label>
-                        <select class="form-select me-5" id="model-select" style="width: auto;"></select>
-                        <label for="chat-select" class="me-2" style="font-size: normal;">History:</label>
-                        <select id="chat-select" class="form-select me-2" style="width: auto;">
-                            <option value="" disabled selected>Select a chat</option>
-                        </select>
-                    </div>
-                    <div class="p-auto flex-grow-1 bd-highlight">
-                        <div class="d-flex flex-column">
-                        <button id="new-chat" class="btn btn-dark mb-2" type="button">Reset</button>
-                        <button id="save-chat" class="btn btn-secondary mb-2" type="button" data-bs-toggle="modal" data-bs-target="#nameModal">Save</button>
-                        <button id="delete-chat" class="btn btn-danger" type="button">Delete</button>
-                      </div>
-                    </div>
-                </div>
+          </div>
+          <div class="d-flex align-items-center m-2">
+            <div class="p-2 flex-grow-1 bd-highlight">
+              <label for="model-select" class="me-2" style="font-size: normal;">Model:</label>
+              <select class="form-select me-5" id="model-select" style="width: auto;"></select>
+              <label for="chat-select" class="me-2" style="font-size: normal;">History:</label>
+              <select id="chat-select" class="form-select me-2" style="width: auto;">
+                <option value="" disabled selected>Select a chat</option>
+              </select>
             </div>
+            <div class="p-auto flex-grow-1 bd-highlight">
+              <div class="d-flex flex-column">
+                <button id="new-chat" class="btn btn-dark mb-2" type="button">Reset</button>
+                <button id="save-chat" class="btn btn-secondary mb-2" type="button" data-bs-toggle="modal" data-bs-target="#nameModal">Save</button>
+                <button id="delete-chat" class="btn btn-danger" type="button">Delete</button>
+              </div>
+            </div>
+          </div>
         </div>
+      </div>
 
 
 
 
-    <div class="container p-2 card" id="input-area">
+      <div class="container p-2 card" id="input-area">
         <div class="input-group">
-                <textarea class="form-control" id="user-input" placeholder="Type your question here..." oninput="autoGrow(this)"></textarea>
-            <button id="send-button" class="btn btn-primary">Send</button>
-        </div>
-    </div>
-
-<!-- Modal -->
-<div class="modal fade" id="nameModal" tabindex="-1" aria-labelledby="nameModalLabel" aria-hidden="true" >
-    <div class="modal-dialog" >
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title" id="nameModalLabel">Enter Your Name</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-        </div>
-        <div class="modal-body">
-          <input type="text" class="form-control" id="userName" placeholder="Your Name">
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-          <button type="button" class="btn btn-primary" id="saveName">Save</button>
+          <textarea class="form-control" id="user-input" placeholder="Type your question here..." oninput="autoGrow(this)"></textarea>
+          <button id="send-button" class="btn btn-primary">Send (CTRL+Enter)</button>
         </div>
       </div>
-    </div>
-  </div>
 
-  <div class="modal fade" id="errorModal" tabindex="-1">
-    <div class="modal-dialog modal-xl">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title">Unable to access Ollama server</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-        </div>
-        <div class="modal-body">
-          <p id="errorText"></p>
+      <!-- Modal -->
+      <div class="modal fade" id="nameModal" tabindex="-1" aria-labelledby="nameModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title" id="nameModalLabel">Enter Your Name</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+              <input type="text" class="form-control" id="userName" placeholder="Your Name">
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+              <button type="button" class="btn btn-primary" id="saveName">Save</button>
+            </div>
+          </div>
         </div>
       </div>
-    </div>
-  </div>
 
-  <script src="api.js"></script>
-  <script src="chat.js"></script>
+      <div class="modal fade" id="errorModal" tabindex="-1">
+        <div class="modal-dialog modal-xl">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title">Unable to access Ollama server</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+              <p id="errorText"></p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <script src="api.js"></script>
+      <script src="chat.js"></script>
 
 </body>
 

--- a/manifest.json
+++ b/manifest.json
@@ -8,13 +8,14 @@
     "declarativeNetRequest"
   ],
   "host_permissions": [
-    "http://*:11434/api/tags",
-    "http://*:11434/api/generate",
-    "https://*:11434/api/tags",
-    "https://*:11434/api/generate"
+    "http://*/api/tags",
+    "http://*/api/generate",
+    "https://*/api/tags",
+    "https://*/api/generate"
   ],
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "scripts": ["background.js"]
   },
   "icons": {
     "16": "icon16.png",


### PR DESCRIPTION
This PR fixes Firefox streams not working, `fetch` is replaced with `XMLHttpRequest`

Doing `await` (or `.then`) on a `fetch` function waits for the whole response on Firefox. (Bad, streaming doesn't work)

On Chrome, it just waits until some data is received and then returns the fetch. (Good, streaming works!)

This is why the switch to `XMLHttpRequest` was made.

Still works on Chrome and Firefox! 💪🏼 

I also removed the `responseDiv.hidden_text` as its just- stupid, and replaced it with `responseWords`, the `copy` button still works

## `manifest.json`

I removed the need for the port as I personally host Ollama on a different port however, this can be undone.
I also **added** `background.scripts` as Firefox doesn't support the `background.service_worker`

See: https://stackoverflow.com/a/78088358

As well as some just indent/spacing changes as it was all over the place, fixed by running `Format Document` in vscode

If I'm allowed to, I can publish the Firefox addon however as a side note I was having problems with the `integrity` checks when running in a local environment soooo 🤷🏼 