### PR TITLE
Add credentials: include to fetch requests

### DIFF
--- a/api.js
+++ b/api.js
@@ -58,7 +58,7 @@ function setSystemPrompt(){
 
 
 async function getModels(){
-  const response = await fetch(`${ollama_host}/api/tags`);
+  const response = await fetch(`${ollama_host}/api/tags`, {credentials: 'include'});
   const data = await response.json();
   return data;
 }
@@ -73,7 +73,8 @@ function postRequest(data, signal) {
       'Content-Type': 'application/json'
     },
     body: JSON.stringify(data),
-    signal: signal
+    signal: signal,
+    credentials: 'include',
   });
 }
 


### PR DESCRIPTION
## Problem
Cross-origin fetch requests to the Ollama server omit cookies by default, breaking the UI when used over connections that require authentication cookies (e.g., Google Colab, remote VMs with cookie-based auth).

## Solution
Add `credentials: 'include'` to both `getModels()` and `postRequest()` fetch calls in api.js. This allows cookies to be sent with cross-origin requests.

## Use case
Users running ollama-ui on Google Colab or remote servers where Ollama traffic is gated by authentication cookies can use the UI without CORS errors.